### PR TITLE
Add Acl to put function, Update spec & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Rest client for [BCDB](https://github.com/threefoldtech/bcdb)
 - run bcdb : `./bcdb --seed-file user.seed `
 - now you can talk to `bcdb` through http via unix socket `/tmp/bcdb.sock`
 
+##### Copy zdb and bcdb to your local user **Optional**
+- You can copy zdb and bcdb to _/usr/local/bin_ to be able to use them from terminal directly as follow:
+  - `sudo cp {0-db folder path}/bin/zdb /usr/local/bin`
+  - `sudo cp {bcdb folder path}/target/x86_64-unknown-linux-musl/release/bcdb /usr/local/bin`
+- Now you can use them as follow:
+  - For 0-db: `zdb --mode seq --data {path to data folder} --index {path to index folder}`
+  
+  > You have to choose the path of data and index folders as you prefer, the default path is the same folder zdb run from. 
+  
+  - For bcdb: `bcdb --seed-file user.seed`
+
 ##### Use the library in your application
 
 **WARNING**
@@ -83,6 +94,11 @@ res = client.acl.get(acl)
 pp! res => {"permission" => "r--", "users" => [2, 3]}
 
 client.acl.list => [{"id" => 0, "permission" => "r--", "users" => [1, 2]}]
+
+# Put with Acls
+key_acl = c.put value: "b", tags: tags, acl: acl
+res_acl = c.get(key_acl)
+res_acl["tags"][":acl"].should eq acl.to_s
 
 ```
 ##### Dealing with another bcdb

--- a/README.md
+++ b/README.md
@@ -95,10 +95,16 @@ pp! res => {"permission" => "r--", "users" => [2, 3]}
 
 client.acl.list => [{"id" => 0, "permission" => "r--", "users" => [1, 2]}]
 
-# Put with Acls
+# Put & Update with Acls
+
 key_acl = c.put value: "b", tags: tags, acl: acl
 res_acl = c.get(key_acl)
 res_acl["tags"][":acl"].should eq acl.to_s
+
+new_acl = c.acl.set("rwd", [5,6])
+c.update key: key_acl, value: "b", tags: tags, acl: new_acl
+res_acl = c.get(key_acl)
+res_acl["tags"][":acl"].should eq new_acl.to_s
 
 ```
 ##### Dealing with another bcdb

--- a/spec/bcdb-client_spec.cr
+++ b/spec/bcdb-client_spec.cr
@@ -3,16 +3,21 @@ require "json"
 require "uuid"
 
 describe Bcdb::Client do
-   it "add acl to put function" do
+   it "add acl to put & update function" do
     client = Bcdb::Client.new unixsocket: "/tmp/bcdb.sock", db: "db", namespace: "example"
     random_tag = "#{UUID.random.to_s}"
     tags = {"example" => random_tag, "tag" => "abc"}
     acl = client.acl.set("r--", [1,2])
-
+    
     key = client.put value: "a", tags: tags, acl: acl
 
     res = client.get(key)
     res["tags"][":acl"].should eq acl.to_s
+
+    new_acl = client.acl.set("rw-", [3,4])
+    client.update key: key, value: "a", tags: tags, acl: new_acl
+    res = client.get(key)
+    res["tags"][":acl"].should eq new_acl.to_s
   end
   
   it "works" do

--- a/spec/bcdb-client_spec.cr
+++ b/spec/bcdb-client_spec.cr
@@ -3,6 +3,18 @@ require "json"
 require "uuid"
 
 describe Bcdb::Client do
+   it "add acl to put function" do
+    client = Bcdb::Client.new unixsocket: "/tmp/bcdb.sock", db: "db", namespace: "example"
+    random_tag = "#{UUID.random.to_s}"
+    tags = {"example" => random_tag, "tag" => "abc"}
+    acl = client.acl.set("r--", [1,2])
+
+    key = client.put value: "a", tags: tags, acl: acl
+
+    res = client.get(key)
+    res["tags"][":acl"].should eq acl.to_s
+  end
+  
   it "works" do
     client = Bcdb::Client.new unixsocket: "/tmp/bcdb.sock", db: "db", namespace: "example" 
     random_tag = "#{UUID.random.to_s}"

--- a/src/bcdb.cr
+++ b/src/bcdb.cr
@@ -247,7 +247,7 @@ module Bcdb
       @acl = Acl.new unixsocket: unixsocket, path: "/acl", pool: pool
     end
 
-    def put(value : String, tags : Hash(String, String|Int32|Bool) = Hash(String, String|Int32|Bool).new, threebot_id : String = "")
+    def put(value : String, tags : Hash(String, String|Int32|Bool) = Hash(String, String|Int32|Bool).new, threebot_id : String = "", acl : UInt64 = 0)
       resp = nil
       
       headers = HTTP::Headers{
@@ -260,6 +260,10 @@ module Bcdb
         headers["x-threebot-id"] = threebot_id
       end
 
+      if acl != 0_u64
+        headers["x-acl"] = acl.to_s
+      end
+      
       exec method: post, path: @path, headers: headers, body: value 
       return resp.not_nil!.body.to_u64
     end

--- a/src/bcdb.cr
+++ b/src/bcdb.cr
@@ -268,7 +268,7 @@ module Bcdb
       return resp.not_nil!.body.to_u64
     end
 
-    def update(key : Int32|Int64|UInt64, value : String, tags : Hash(String, String|Int32|Bool) = Hash(String, String|Int32|Bool).new, threebot_id : String = "")
+    def update(key : Int32|Int64|UInt64, value : String, tags : Hash(String, String|Int32|Bool) = Hash(String, String|Int32|Bool).new, threebot_id : String = "", acl : UInt64 = 0)
       resp = nil
       headers = HTTP::Headers{
         "X-Unix-Socket" => @unixsocket,
@@ -278,6 +278,10 @@ module Bcdb
       
       if threebot_id != ""
         headers["x-threebot-id"] = threebot_id
+      end
+
+      if acl != 0_u64
+        headers["x-acl"] = acl.to_s
       end
 
       exec method: put, path: "#{@path}/#{key.to_s}", headers: headers, body: value


### PR DESCRIPTION
## Description
- In this PR, I update the following:

1. Modify put function in Client class to add acl as an argument.
2. Modify bcdb_client_spec with a new spec for the modified method.
3. Add a description to copy zdb and bcdb to the local user folder
to use them easily from the terminal and illustrate the usage of --data and --index flags.
4. Add the put method with acl under Acls section in the code part In README.